### PR TITLE
fix: ensure `python3` symlink points to expected Python version in 20.5 container

### DIFF
--- a/dockerfiles/20.5/Dockerfile
+++ b/dockerfiles/20.5/Dockerfile
@@ -37,6 +37,9 @@ RUN apt update \
     # Some tools like rez can require a bare 'python' call to run, so generate a symlink for that name
     # to the link containing the major.minor version.
     && ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python \
+    # Remove and recreate the 'python3' symlink as it will be pointing to the OS default, 3.12.
+    && rm -f /usr/bin/python3 \
+    && ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python3 \
     # Remove any externally managed file if it exists as we want to easily be able to install tools via \
     # pip without the OS/Python getting in the way.
     && rm -f /usr/lib/python${PYTHON_VERSION}/EXTERNALLY-MANAGED \

--- a/tests/run_built_container_tests.bash
+++ b/tests/run_built_container_tests.bash
@@ -15,6 +15,8 @@ python --version | grep ${_CONTAINER_PYTHON_VERSION}
 python3 --version | grep ${_CONTAINER_PYTHON_VERSION}
 rez-env python -- python --version | grep ${_CONTAINER_PYTHON_VERSION}
 
-# Test that pip works
-pip install requests==2.32.3
-python -c "import requests; print(requests.__version__)" | grep "2.32.3"
+# Test that pip is accessible and sourced from the correct Python version.
+pip --version | grep "python${_CONTAINER_PYTHON_VERSION}"
+pip3 --version | grep "python${_CONTAINER_PYTHON_VERSION}"
+python -m pip --version | grep "python${_CONTAINER_PYTHON_VERSION}"
+python3 -m pip --version | grep "python${_CONTAINER_PYTHON_VERSION}"


### PR DESCRIPTION
fixes #4