### PR TITLE
fix: hardcoded 20.5's Qt.py rez package version to 1.4.1

### DIFF
--- a/.github/workflows/build_houdini_image.yml
+++ b/.github/workflows/build_houdini_image.yml
@@ -86,7 +86,7 @@ jobs:
           # Tag the new image with the full version and the major.minor (e.g. 20.0.724, 20.0)
           tags: ${{ env.TAG_NAME }}:${{ steps.checker.outputs.build_full_version }},${{ env.TAG_NAME }}:${{ steps.checker.outputs.build_version }}
 
-      - name: Test hython
+      - name: Test built image
         if: steps.checker.outputs.build_version != ''
         run: |
           docker run -e CLIENT_ID=${{ secrets.SESI_CLIENT_ID }} -e CLIENT_SECRET=${{ secrets.SESI_CLIENT_SECRET }} -e LICENSE_SERVER=${{ secrets.LICENSE_SERVER }} -v ./tests:${{ env.TEST_DIR }} -w ${{ env.TEST_DIR }} ${{ env.TAG_NAME }}:${{ steps.checker.outputs.build_full_version }} ./run_built_container_tests.bash

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,7 @@ dist
 
 TODO
 
+# Local repo files I don't want to commit
 install_houdini_launcher.sh
 docker-compose.yml
+run_local_build_tests_command

--- a/dockerfiles/20.5/Dockerfile
+++ b/dockerfiles/20.5/Dockerfile
@@ -122,7 +122,7 @@ RUN mkdir ${_REZ_PACKAGE_DIR} \
     && rez-pip --install pytest-qt \
     && rez-pip --install pytest-subprocess \
     && rez-pip --install python_singleton \
-    && rez-pip --install Qt.py \
+    && rez-pip --install Qt.py==1.4.1 \
     && rez-pip --install ruff \
     && rez-pip --install scipy \
     && rez-pip --install sphinx \


### PR DESCRIPTION
This will avoid apparent rez-pip issues with the latest version.

fixes #6