### PR TITLE
fix rez-pip install issue with local paths in RECORD file

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,6 @@ packages which are designed to help facilitate testing.
 ### Other
 - [numpy](https://pypi.org/project/numpy/) - The installed version matches that of the VFX Platform year 
 - [PySide2](https://pypi.org/project/PySide2/) or [PySide6](https://pypi.org/project/PySide6/) - The installed version matches that of the VFX Platform year 
-- [Qt.py](https://pypi.org/project/Qt.py/) - Qt.py is currently not provided for images featuring Qt6 (21.0)
+- [Qt.py](https://pypi.org/project/Qt.py/)
 - [scipy](https://pypi.org/project/scipy/)
 - [sphinx](https://pypi.org/project/Sphinx/)

--- a/dockerfiles/21.0/Dockerfile
+++ b/dockerfiles/21.0/Dockerfile
@@ -82,6 +82,11 @@ ENV _CONTAINER_PYTHON_VERSION=3.11
 
 ARG REZ_DIR="/opt/rez"
 
+# Copy in our rezconfig.py file to the rez install directory and sent the config env
+# var to point to it.
+COPY rezconfig.py ${REZ_DIR}/
+ENV REZ_CONFIG_FILE=${REZ_DIR}/rezconfig.py
+
 # Clone custom bind files and add them to the search bath
 ADD https://github.com/captainhammy/rez-bind-files.git ${REZ_DIR}/bind_files
 ENV REZ_BIND_MODULE_PATH=${REZ_DIR}/bind_files/bind
@@ -122,23 +127,11 @@ RUN mkdir ${_REZ_PACKAGE_DIR} \
     && rez-pip --install pytest-qt \
     && rez-pip --install pytest-subprocess \
     && rez-pip --install python_singleton \
+    && rez-pip --install Qt.py \
     && rez-pip --install ruff \
     && rez-pip --install scipy \
     && rez-pip --install sphinx \
     && rez-pip --install tox
-
-# Qt.py currently has issues being installed by rez-pip, so build the latest
-# tag from source.
-# Even this no longer works, so we will skip for now.
-#RUN git -C /tmp clone https://github.com/mottosso/Qt.py.git \
-#    && cd /tmp/Qt.py \
-#    && git fetch --tags \
-#    && latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) \
-#    && git checkout $latestTag \
-#    && python3 setup.py bdist_wheel \
-#    && rez-pip -i dist/qt_py-$latestTag-*.whl \
-#    && cd - \
-#    && rm -rf /tmp/Qt.py
 
 # Install Houdini Rez CMake tools
 RUN git -C /tmp/ clone https://github.com/captainhammy/houdini-rez-cmake-tools.git \

--- a/dockerfiles/21.0/rezconfig.py
+++ b/dockerfiles/21.0/rezconfig.py
@@ -1,0 +1,40 @@
+pip_install_remaps = [
+    {
+        "record_path": r"{p}{s}{p}{s}(share{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+    {
+        "record_path": r"^{p}{s}{p}{s}(LICENSE.txt)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+
+    {
+        "record_path": r"^{p}{s}{p}{s}(include{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+    {
+        "record_path": r"^{p}{s}{p}{s}(bin{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+    {
+        "record_path": r"^{p}{s}{p}{s}(share{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+
+    {
+        "record_path": r"^{p}{s}{p}{s}(etc{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+
+    {
+        "record_path": r"^{p}{s}{p}{s}lib/python/(.*)",
+        "pip_install": r"\1",
+        "rez_install": r"python/\1",
+    }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@
             "D105",  # Missing docstring in magic method
             "D107",  # Missing docstring in __init__
             "TRY003",  # Exception long messages
+            "I001",  # Import sort order conflicts with isort
         ]
 
     [tool.ruff.lint.per-file-ignores]

--- a/python/hython_docker_image_builder/builder.py
+++ b/python/hython_docker_image_builder/builder.py
@@ -17,6 +17,7 @@ import requests
 import sidefx  # type: ignore
 from hython_docker_image_builder import docker
 
+# Globals
 TOKEN_URL = "https://www.sidefx.com/oauth2/application_token"
 ENDPOINT_URL = "https://www.sidefx.com/api/"
 


### PR DESCRIPTION
bug: fix rez-pip install issue with local paths in RECORD file by adding a custom rezconfig.py file

ci: disable ruff I001 as its expected order conflicts with isort

feat: re-enable installing Qt.py as it now seems to work with some combination of Python 3.11 and recent versions of rez.

style: add Globals heading to builder.py