### PR TITLE
feat: add Houdini 22.0 support

### DIFF
--- a/.github/workflows/build_houdini_image.yml
+++ b/.github/workflows/build_houdini_image.yml
@@ -45,7 +45,7 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Install project
-        run: poetry install --no-interaction --no-root
+        run: poetry install --no-interaction
 
       - name: Check for build
         id: checker

--- a/.github/workflows/build_houdini_image.yml
+++ b/.github/workflows/build_houdini_image.yml
@@ -2,7 +2,7 @@ name: Docker Image Builder
 
 on:
   schedule:
-    # Run every day at 9:15 PM UTC which should be after any time
+    # Run every day at 9:15 PM UTC, which should be after any time
     # SideFX would have updated the production builds.
     - cron: '15 21 * * *'
 
@@ -26,24 +26,31 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
          python-version: 3.13
 
-      - name: Install dependencies
-        run: python3 -m pip install --group "deps"
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          virtualenvs-path: .venv
+          installer-parallel: true
 
-      # Update our PYTHONPATH so that it can execute our own repository tools.
-      - name: Set Local PYTHONPATH
-        run: |
-          echo "PYTHONPATH=${GITHUB_WORKSPACE}/python:${PYTHONPATH}" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: poetry install --no-interaction --no-root
+
+      - name: Install project
+        run: poetry install --no-interaction --no-root
 
       - name: Check for build
         id: checker
         run: |
+          source .venv/bin/activate
           python bin/get_houdini_version_to_build.py ${{ env.FORCE_BUILD == 'true' && '--force' || '' }} ${{ inputs.houdini-version || '""' }} ${{ env.TAG_NAME }} ${{ secrets.SESI_CLIENT_ID }} ${{ secrets.SESI_CLIENT_SECRET }}
 
       - name: Ensure disk space
@@ -53,24 +60,24 @@ jobs:
           sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1 || true
           df . -h
 
-      - name: Set up QEMU
-        if: steps.checker.outputs.build_version != ''
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        if: steps.checker.outputs.build_version != ''
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to Docker Hub
         if: steps.checker.outputs.build_version != ''
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up QEMU
+        if: steps.checker.outputs.build_version != ''
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        if: steps.checker.outputs.build_version != ''
+        uses: docker/setup-buildx-action@v4
+
       - name: Build docker image
         if: steps.checker.outputs.build_version != ''
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: dockerfiles/${{ steps.checker.outputs.build_version }}
           # So we can test the image after building
@@ -79,7 +86,7 @@ jobs:
             HOUDINI_VERSION=${{ steps.checker.outputs.build_full_version }}
             HOUDINI_INSTALLER_FILENAME=${{ steps.checker.outputs.houdini_launcher_filename }}
             HOUDINI_ISO_FILENAME=${{ steps.checker.outputs.houdini_iso_filename }}
-          # Tag the new image with the full version and the major.minor (e.g. 20.0.724, 20.0)
+          # Tag the new image with the full version and the major.minor (e.g., 20.0.724, 20.0)
           tags: ${{ env.TAG_NAME }}:${{ steps.checker.outputs.build_full_version }},${{ env.TAG_NAME }}:${{ steps.checker.outputs.build_version }}
 
       - name: Test built image

--- a/.github/workflows/run_image_tests.yml
+++ b/.github/workflows/run_image_tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Run Image Tests
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/README.md
+++ b/README.md
@@ -20,22 +20,23 @@ LICENSE AGREEMENT](https://www.sidefx.com/legal/license-agreement/)
 Each image for a particular build of Houdini provides versions of related tools matching those of the [VFX Platform](https://vfxplatform.com/).
 
 Currently, all images provided are created using the **default** build of Houdini, which means libraries that match
-those of the VFX Platform year, and not builds with alternative Python or GCC versions.
+those of the VFX Platform year and not builds with alternative Python or GCC versions.
 
-| Houdini Version | Linux Image  | VFX Platform Year | Python Version | GCC Version    |
-|-----------------|--------------|-------------------|----------------| ---------------|
-| 21.0            | ubuntu:noble | 2025              | 3.11           | 11.2           |
-| 20.5            | ubuntu:noble | 2024              | 3.11           | 11.2           |
-| 20.0            | ubuntu:jammy | 2023              | 3.10           | 11.2           |
-| 19.5            | ubuntu:focal | 2022              | 3.9            | 9.3            |
+| Houdini Version | Linux Image      | VFX Platform Year | Python Version | GCC Version |
+|-----------------|------------------|-------------------|----------------|-------------|
+| 22.0            | ubuntu:noble     | 2026              | 3.13           | 14.2        |
+| 21.0            | ubuntu:noble     | 2025              | 3.11           | 11.2        |
+| ~~20.5~~        | ~~ubuntu:noble~~ | ~~2024~~          | ~~3.11~~       | ~~11.2~~    |
+| ~~20.0~~        | ~~ubuntu:jammy~~ | ~~2023~~          | ~~3.10~~       | ~~11.2~~    |
+| ~~19.5~~        | ~~ubuntu:focal~~ | ~~2022~~          | ~~3.9~~        | ~~9.3~~     |
 
 # Installed System Packages
 
 The following notable system packages are installed:
 
-- git - Available to allow you to check out code required for testing 
-- gcc / cmake / build related packages - Packages related to C++ compilation are included to enable building HDK plugins.
-- nodejs - Node.js (v20) is installed to facilitate various GitHub Action workflows which rely on it.
+- git – Available to allow you to check out code required for testing 
+- gcc / cmake / build-related packages – Packages related to C++ compilation are included to enable building HDK plugins.
+- nodejs - Node.js (v24) is installed to facilitate various GitHub Action workflows which rely on it.
 
 # Houdini Specifics
 
@@ -55,7 +56,7 @@ If you need any of these, it is recommended to explicitly source the setup file.
 
 ## License Setup
 
-The `hython-runner` containers do not have any Houdini licensing set up which means that Houdini related programs
+The `hython-runner` containers do not have any Houdini licensing configured, which means that Houdini related programs
 which require a license will not function by default. **You** are responsible for configuring your own licensing
 setup.
 
@@ -63,13 +64,13 @@ setup.
 
 It should be possible to compile HDK plugins right out of the box, using either `hcustom` or `cmake`.
 
-The `CMAKE_PREFIX_PATH` variable is defined and pointing to the `$HT/cmake` directory such that if you are using cmake
+The `CMAKE_PREFIX_PATH` variable is defined and pointing to the `$HT/cmake` directory so that if you are using cmake
 to compile HDK plugins, it will be able to find the Houdini config without additional setup.
 
 # Rez
 
 The [rez](https://rez.readthedocs.io/en/stable/) package manager is also available for workflows which use it. A number of already bound or installed
-packages which are designed to help facilitate testing.
+packages that are designed to help facilitate testing.
 
 
 ## Bound Rez Packages
@@ -91,8 +92,8 @@ packages which are designed to help facilitate testing.
 
 ### Other
 - [humanfriendly](https://pypi.org/project/humanfriendly/)
-- [numpy](https://pypi.org/project/numpy/) - The installed version matches that of the VFX Platform year 
-- [PySide2](https://pypi.org/project/PySide2/) or [PySide6](https://pypi.org/project/PySide6/) - The installed version matches that of the VFX Platform year 
+- [numpy](https://pypi.org/project/numpy/) – The installed version matches that of the VFX Platform year 
+- [PySide2](https://pypi.org/project/PySide2/) or [PySide6](https://pypi.org/project/PySide6/) – The installed version matches that of the VFX Platform year 
 - [python_singleton](https://pypi.org/project/python-singleton/)
 - [Qt.py](https://pypi.org/project/Qt.py/)
 - [scipy](https://pypi.org/project/scipy/)

--- a/dockerfiles/22.0/Dockerfile
+++ b/dockerfiles/22.0/Dockerfile
@@ -1,6 +1,6 @@
 ARG OS_IMAGE=ubuntu:noble
-ARG PYTHON_VERSION=3.11
-ARG GCC_VERSION=11
+ARG PYTHON_VERSION=3.13
+ARG GCC_VERSION=14
 
 FROM ${OS_IMAGE} AS houdini-install
 
@@ -25,8 +25,8 @@ ADD --chmod=755 ${HOUDINI_INSTALLER_FILENAME} ${HOUDINI_ISO_FILENAME} ./
 
 RUN apt update \
     && apt upgrade -y \
-    && apt install -y tzdata csh curl git pkg-config procps wget software-properties-common ${GCC_VERSION} g++-${GCC_VERSION} libglu1-mesa libsm6 bc libnss3 libx11-6 libx11-xcb1 libxcb1 libxcb1-dev libxcb-icccm4 libx11-xcb-dev libxrandr2 libxcomposite-dev libxdamage1 libxcursor1 libxi6 libxkbcommon-x11-0 libxtst6 libfontconfig1 libxss1 libpci3 libasound2t64 libx11-dev libxi-dev libgl-dev build-essential gfortran cmake \
-    # Python 3.11 for noble is not available in the standard repositories so we'll need to access it from deadsnakes.
+    && apt install -y tzdata csh curl git pkg-config procps wget software-properties-common gcc-${GCC_VERSION} g++-${GCC_VERSION} libglu1-mesa libsm6 bc libnss3 libx11-6 libx11-xcb1 libxcb1 libxcb1-dev libxcb-icccm4 libx11-xcb-dev libxrandr2 libxcomposite-dev libxdamage1 libxcursor1 libxi6 libxkbcommon-x11-0 libxtst6 libfontconfig1 libxss1 libpci3 libasound2t64 libx11-dev libxi-dev libgl-dev build-essential gfortran cmake \
+    # Python 3.13 for noble is not available in the standard repositories so we'll need to access it from deadsnakes.
     && add-apt-repository -y ppa:deadsnakes/ppa \
     && apt update \
     && apt install -y python${PYTHON_VERSION} python${PYTHON_VERSION}-venv \
@@ -50,13 +50,12 @@ RUN apt update \
     && rm get-pip.py
 
 # Install Houdini and the license server.
-# Create '/usr/share/applications/' first, if it doesnt exist, so the installer won't fail trying to install shortcuts.
 RUN ./${HOUDINI_INSTALLER_FILENAME} --no-desktop-menus --quiet launcher \
     && launcher/bin/houdini_installer install Houdini --accept-EULA SideFX-${EULA_DATE} --accept-EULA SideFX-Beta-${EULA_DATE} --offline-installer ${HOUDINI_ISO_FILENAME} --desktop-menus no --installdir ${HOUDINI_INSTALL_DIR} \
     && launcher/bin/houdini_installer install "License Server" --accept-EULA SideFX-${EULA_DATE} --accept-EULA  SideFX-Beta-${EULA_DATE} --offline-installer ${HOUDINI_ISO_FILENAME} \
     # We're done with the launcher and source files so we can remove them all.
     # Also, remove extra files we don't want to slim down the eventual image.
-    && rm -rf /tmp/houdini_installation ${HOUDINI_INSTALL_DIR}/houdini/pic ${HOUDINI_INSTALL_DIR}/houdini/help ${HOUDINI_INSTALL_DIR}/houdini/public
+    && rm -rf /tmp/houdini_installation ${HOUDINI_INSTALL_DIR}/houdini/pic ${HOUDINI_INSTALL_DIR}/houdini/help ${HOUDINI_INSTALL_DIR}/houdini/public /opt/sidefx
 
 # Install the latest release tag of rez.
 
@@ -82,6 +81,11 @@ ARG GCC_VERSION
 ENV _CONTAINER_PYTHON_VERSION=${PYTHON_VERSION}
 
 ARG REZ_DIR="/opt/rez"
+
+# Copy in our rezconfig.py file to the rez install directory and sent the config env
+# var to point to it.
+COPY rezconfig.py ${REZ_DIR}/
+ENV REZ_CONFIG_FILE=${REZ_DIR}/rezconfig.py
 
 # Clone custom bind files and add them to the search bath
 ADD https://github.com/captainhammy/rez-bind-files.git ${REZ_DIR}/bind_files
@@ -114,8 +118,8 @@ RUN mkdir ${_REZ_PACKAGE_DIR} \
     && rez-bind cmake \
     && rez-bind gcc --exe /usr/bin/gcc-${GCC_VERSION} \
     && rez-pip --install humanfriendly \
-    && rez-pip --install 'numpy<1.25' \
-    && rez-pip --install 'PySide6<6.6' \
+    && rez-pip --install 'numpy<2.4' \
+    && rez-pip --install 'PySide6<6.9' \
     && rez-pip --install pytest \
     && rez-pip --install pytest-cov \
     && rez-pip --install pytest-datadir \

--- a/dockerfiles/22.0/rezconfig.py
+++ b/dockerfiles/22.0/rezconfig.py
@@ -1,0 +1,40 @@
+pip_install_remaps = [
+    {
+        "record_path": r"{p}{s}{p}{s}(share{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+    {
+        "record_path": r"^{p}{s}{p}{s}(LICENSE.txt)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+
+    {
+        "record_path": r"^{p}{s}{p}{s}(include{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+    {
+        "record_path": r"^{p}{s}{p}{s}(bin{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+    {
+        "record_path": r"^{p}{s}{p}{s}(share{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+
+    {
+        "record_path": r"^{p}{s}{p}{s}(etc{s}.*)",
+        "pip_install": r"\1",
+        "rez_install": r"\1",
+    },
+
+    {
+        "record_path": r"^{p}{s}{p}{s}lib/python/(.*)",
+        "pip_install": r"\1",
+        "rez_install": r"python/\1",
+    }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [project]
 name = "hython_docker_image_builder"
+description = "Package to build a hython docker image"
+version = "0.0.1"
 
 requires-python = ">=3.13"
 dependencies = [
@@ -8,55 +10,69 @@ dependencies = [
 ]
 
 [dependency-groups]
-    deps = ["requests", "urllib3"]
     docstrings = ["pydocstringformatter"]
     github = ["coverage", "tox"]
     isort = ["isort"]
-    mypy = ["mypy[toml]", "types-requests", "types-PyYAML"]
     ruff = ["ruff"]
-    test = ["pytest", "pytest_cov", "pytest_datadir", "pytest_mock", "pytest-subprocess"]
+    test = ["pytest", "pytest-cov", "pytest-datadir", "pytest-mock", "pytest-subprocess"]
+    ty = ["ty"]
+
+[tool.poetry]
+packages = [
+    {include = "hython_docker_image_builder", from="python"},
+    {include = "sidefx.py", from="python"},
+]
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.tox]
-    env_list = ["py313", "ruff-check", "ruff-format-check", "isort-check", "mypy", "docstring-check"]
+    env_list = ["py313", "ruff-check", "ruff-format-check", "isort-check", "ty", "docstring-check"]
     labels = {test = ["py313"], static = ["ruff-check", "ruff-format-check", "isort-check", "mypy", "docstring-check"], fix = ["ruff-format-fix", "isort-run", "docstring-run"] }
-    no_package = true
 
     [tool.tox.env.py313]
         allowlist_externals = ["echo"]
-        dependency_groups = ["deps", "test"]
-        set_env = {PYTHONPATH = "{toxinidir}/python"}
+        dependency_groups = ["test"]
         commands = [["pytest", "tests/python"]]
         commands_post = [["echo", "View test coverage report at file://{toxinidir}/coverage_html_report/index.html"]]
 
     [tool.tox.env.ruff-check]
+        skip_install = true
         dependency_groups = ["ruff"]
         commands = [[ "ruff", "check", "--preview", "bin/", "python/hython_docker_image_builder/", "tests/"]]
 
     [tool.tox.env.ruff-format-check]
+        skip_install = true
         dependency_groups = ["ruff"]
         commands = [[ "ruff", "format", "--preview", "--check", "--diff", "bin/", "python/hython_docker_image_builder/", "tests/"]]
 
     [tool.tox.env.ruff-format-fix]
+        skip_install = true
         dependency_groups = ["ruff"]
         commands = [[ "ruff", "format", "--preview", "bin/", "python/hython_docker_image_builder/", "tests/"]]
 
     [tool.tox.env.isort-check]
+        skip_install = true
         dependency_groups = ["isort"]
         commands = [[ "isort", "--check", "bin/", "python/hython_docker_image_builder/", "tests/"]]
 
     [tool.tox.env.isort-run]
+        skip_install = true
         dependency_groups = ["isort"]
         commands = [[ "isort", "bin/", "python/hython_docker_image_builder/", "tests/"]]
 
-    [tool.tox.env.mypy]
-        dependency_groups = ["deps", "mypy"]
-        commands = [[ "mypy", "bin", "python/hython_docker_image_builder"]]
+    [tool.tox.env.ty]
+        dependency_groups = ["ty", "test"]
+        commands = [[ "ty", "check", "bin/", "python/hython_docker_image_builder/", "tests/"]]
 
     [tool.tox.env.docstring-check]
+        skip_install = true
         dependency_groups = ["docstrings"]
         commands = [[ "pydocstringformatter", "--exit-code", "bin/", "python/hython_docker_image_builder/"]]
 
     [tool.tox.env.docstring-run]
+        skip_install = true
         dependency_groups = ["docstrings"]
         commands = [[ "pydocstringformatter", "--write", "bin/", "python/hython_docker_image_builder/"]]
 
@@ -105,6 +121,13 @@ dependencies = [
     disallow_untyped_defs = true
     follow_imports = "skip"
 
+[tool.ty]
+    [tool.ty.analysis]
+        allowed-unresolved-imports = ["sidefx"]
+
+    [tool.ty.environment]
+        root = ["./python"]
+
 [tool.ruff]
     line-length = 120
 
@@ -126,6 +149,8 @@ dependencies = [
             "LOG",  #  flake8-logging
             "BLE",  # flake8-blind-except
             "A",  # flake8-builtins
+            "ANN",  # flake8-annotations
+            "Q", # flake8-quotes
             "C4",  # flake8-comprehensions
             "RET",  # flake8-return
             "SIM",  # flake8-simplify
@@ -140,7 +165,8 @@ dependencies = [
             "D104",  # Missing docstring in public module
             "D105",  # Missing docstring in magic method
             "D107",  # Missing docstring in __init__
-            "TRY003",  # Exception long messages
+            "FBT001",  # Boolean type hint
+            "TRY003",  # Long exception messages
             "I001",  # Import sort order conflicts with isort
         ]
 

--- a/python/hython_docker_image_builder/builder.py
+++ b/python/hython_docker_image_builder/builder.py
@@ -1,4 +1,4 @@
-"""Builder related functions."""
+"""Functions related to building images."""
 
 # Future
 from __future__ import annotations
@@ -14,14 +14,18 @@ from operator import itemgetter
 import requests
 
 # hython_docker_image_builder
-import sidefx  # type: ignore
+import sidefx
 from hython_docker_image_builder import docker
 
 # Globals
 TOKEN_URL = "https://www.sidefx.com/oauth2/application_token"
 ENDPOINT_URL = "https://www.sidefx.com/api/"
 
-SUPPORTED_MAJOR_MINOR_VERSIONS = ("20.5", "21.0")
+SUPPORTED_MAJOR_MINOR_VERSIONS = (
+    "20.5",
+    "21.0",
+    "22.0",
+)
 
 # Non-Public Functions
 
@@ -40,11 +44,11 @@ def _determine_version_info(version_arg: str) -> tuple[str | None, str | None]:
     if version_arg:
         components = version_arg.split(".")
 
-        if len(components) < 2:  # noqa: PLR2004
+        if len(components) < 2:  # ruff:ignore[magic-value-comparison]
             raise RuntimeError(f"Invalid version argument: {version_arg} must have at least 2 components")
 
         major_minor = ".".join(components[:2])
-        build = ".".join(components[2:]) if len(components) > 2 else None  # noqa: PLR2004
+        build = ".".join(components[2:]) if len(components) > 2 else None  # ruff:ignore[magic-value-comparison]
 
     else:
         major_minor = None
@@ -73,40 +77,19 @@ def _download_file(url: str, target: pathlib.Path) -> None:
         raise RuntimeError(f"Error downloading file. Returned code {r.status_code}")
 
 
-def _download_product(
-    service: sidefx._Service, release: dict, product: str, target_folder: pathlib.Path
-) -> pathlib.Path:
-    """Download the desired product.
+def _determine_release(releases: list[dict], build: str | None) -> dict:
+    """Determine which of the available releases to install.
 
     Args:
-        service: The SideFX Web API connection.
-        release: The build information dictionary.
-        product: The product name to download.
-        target_folder: The folder to save the downloaded product.
+        releases: A list of available releases.
+        build: The target build to install, if any.
 
     Returns:
-        The downloaded file path.
+        The release to install.
+
+    Raises:
+        RuntimeError: If the target build was specified, but could not be found.
     """
-    product_info = service.download.get_daily_build_download(
-        product=product,
-        version=release["version"],
-        build=release["build"],
-        platform="linux",
-    )
-
-    target = target_folder / product_info["filename"]
-
-    _download_file(product_info["download_url"], target)
-
-    print(f"Downloaded file: {target.resolve().as_posix()}")
-
-    # Verify the file checksum is matching
-    _verify_checksum(target, product_info["hash"])
-
-    return target
-
-
-def _determine_release(releases: list[dict], build: str | None) -> dict:
     if build is not None:
         # Check all the releases for one that matches the target build.
         for release in releases:
@@ -120,47 +103,13 @@ def _determine_release(releases: list[dict], build: str | None) -> dict:
 
     else:
         # Sort the releases by date to actually get the latest production build.
-        # Without doing this, a new build of an older version (e.g. 19.5) would
-        # not be found if any build of a newer version (e.g. 20.0) existed.
+        # Without doing this, a new build of an older version (e.g., 19.5) would
+        # not be found if any build of a newer version (e.g., 20.0) existed.
         releases.sort(key=itemgetter("date"))
 
         release_to_install = releases[-1]
 
     return release_to_install
-
-
-def _get_target_release(service: sidefx._Service, version_arg: str) -> dict:
-    """Get the target release to install.
-
-    `version_arg` can be empty, a {major.minor} or {major.minor.build} type
-    string. If the value is empty, the most recent production build is chosen.
-    If it is a {major.minor}, then that is used to find the latest production build of
-    that release.
-
-    Args:
-        service: The SideFX Web API connection.
-        version_arg: A version string to use in determining which version to install.
-
-    Returns:
-        The target release dictionary.
-
-    Raises:
-        RuntimeError: No matching version could be found to install.
-    """
-    major_minor, build = _determine_version_info(version_arg)
-
-    releases_list = service.download.get_daily_builds_list(
-        product="houdini",
-        version=major_minor,
-        platform="linux",
-        # If no specific build was set, we'll ask for a matching Production build.
-        only_production=not bool(build),
-    )
-
-    if not releases_list:
-        raise RuntimeError(f"No releases matching {major_minor} could be found.")
-
-    return _determine_release(releases_list, build)
 
 
 def _verify_checksum(file_path: pathlib.Path, expected_hash: str) -> None:
@@ -198,7 +147,7 @@ def check_build_can_be_installed(service: sidefx._Service, version_arg: str, tag
     Raises:
         RuntimeError: Raised if the requested {major.minor} version is not supported.
     """
-    target_release = _get_target_release(service, version_arg)
+    target_release = get_target_release(service, version_arg)
 
     version = target_release["version"]
 
@@ -230,8 +179,8 @@ def check_build_can_be_installed(service: sidefx._Service, version_arg: str, tag
     if not build_folder.is_dir():
         raise RuntimeError(f"Cannot find dockerfiles for {version}")
 
-    launcher = _download_product(service, target_release, "houdini-launcher", build_folder)
-    archive = _download_product(service, target_release, "launcher-iso", build_folder)
+    launcher = download_product(service, target_release, "houdini-launcher", build_folder)
+    archive = download_product(service, target_release, "launcher-iso", build_folder)
 
     return {
         "version": version,
@@ -239,6 +188,39 @@ def check_build_can_be_installed(service: sidefx._Service, version_arg: str, tag
         "launcher_name": launcher.name,
         "iso_name": archive.name,
     }
+
+
+def download_product(
+    service: sidefx._Service, release: dict, product: str, target_folder: pathlib.Path
+) -> pathlib.Path:
+    """Download the desired product.
+
+    Args:
+        service: The SideFX Web API connection.
+        release: The build information dictionary.
+        product: The product name to download.
+        target_folder: The folder to save the downloaded product.
+
+    Returns:
+        The downloaded file path.
+    """
+    product_info = service.download.get_daily_build_download(
+        product=product,
+        version=release["version"],
+        build=release["build"],
+        platform="linux_x86_64",
+    )
+
+    target = target_folder / product_info["filename"]
+
+    _download_file(product_info["download_url"], target)
+
+    print(f"Downloaded file: {target.resolve().as_posix()}")
+
+    # Verify the file checksum is matching
+    _verify_checksum(target, product_info["hash"])
+
+    return target
 
 
 def get_service(client_id: str, client_secret: str) -> sidefx._Service:
@@ -251,9 +233,43 @@ def get_service(client_id: str, client_secret: str) -> sidefx._Service:
     Returns:
         A connection to the SideFX Web API.
     """
-    return sidefx.service(  # type: ignore
+    return sidefx.service(
         access_token_url=TOKEN_URL,
         client_id=client_id,
         client_secret_key=client_secret,
         endpoint_url=ENDPOINT_URL,
     )
+
+
+def get_target_release(service: sidefx._Service, version_arg: str) -> dict:
+    """Get the target release to install.
+
+    `version_arg` can be empty, a {major.minor} or {major.minor.build} type
+    string. If the value is empty, the most recent production build is chosen.
+    If it is a {major.minor}, then that is used to find the latest production build of
+    that release.
+
+    Args:
+        service: The SideFX Web API connection.
+        version_arg: A version string to use in determining which version to install.
+
+    Returns:
+        The target release dictionary.
+
+    Raises:
+        RuntimeError: No matching version could be found to install.
+    """
+    major_minor, build = _determine_version_info(version_arg)
+
+    releases_list = service.download.get_daily_builds_list(
+        product="houdini",
+        version=major_minor,
+        platform="linux",
+        # If no specific build was set, we'll ask for a matching Production build.
+        only_production=not bool(build),
+    )
+
+    if not releases_list:
+        raise RuntimeError(f"No releases matching {major_minor} could be found.")
+
+    return _determine_release(releases_list, build)

--- a/python/hython_docker_image_builder/docker.py
+++ b/python/hython_docker_image_builder/docker.py
@@ -1,4 +1,4 @@
-"""Docker related functions."""
+"""Functions related to Docker."""
 
 # Standard Library
 import subprocess

--- a/tests/python/test_builder.py
+++ b/tests/python/test_builder.py
@@ -1,9 +1,13 @@
 """Test the hython_docker_image_builder.build module."""
 
+# Future
+from __future__ import annotations
+
 # Standard Library
-import contextlib
 import http
 import pathlib
+from contextlib import nullcontext
+from typing import TYPE_CHECKING
 
 # Third Party
 import pytest
@@ -11,6 +15,12 @@ import pytest
 # hython_docker_image_builder
 import sidefx
 from hython_docker_image_builder import builder
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pytest_mock import MockerFixture
+
 
 # Tests
 
@@ -23,7 +33,7 @@ from hython_docker_image_builder import builder
         ("321", "321"),
     ),
 )
-def test__determine_release(build, expected):
+def test__determine_release(build: str | None, expected: str | None) -> None:
     """Test hython_docker_image_builder.build._determine_release()."""
     releases = [
         {"build": "456", "date": "2024/10/26", "version": "20.0"},
@@ -31,34 +41,36 @@ def test__determine_release(build, expected):
         {"build": "321", "date": "2024/09/27", "version": "19.0"},
     ]
 
-    raiser = pytest.raises(RuntimeError) if expected is None else contextlib.nullcontext()
+    context = pytest.raises(RuntimeError) if expected is None else nullcontext()
 
-    with raiser:
+    with context:
         result = builder._determine_release(releases, build)
 
         assert result["build"] == expected
 
 
 @pytest.mark.parametrize(
-    "version_str,expected, raiser",
+    "version_str,expected, context",
     (
         ("20", (None, None), pytest.raises(RuntimeError)),
-        ("20.0", ("20.0", None), contextlib.nullcontext()),
-        ("20.0.123", ("20.0", "123"), contextlib.nullcontext()),
-        ("20.0.123.4", ("20.0", "123.4"), contextlib.nullcontext()),
-        ("", (None, None), contextlib.nullcontext()),
+        ("20.0", ("20.0", None), nullcontext()),
+        ("20.0.123", ("20.0", "123"), nullcontext()),
+        ("20.0.123.4", ("20.0", "123.4"), nullcontext()),
+        ("", (None, None), nullcontext()),
     ),
 )
-def test__determine_version_info(version_str, expected, raiser):
+def test__determine_version_info(
+    version_str: str, expected: tuple, context: nullcontext | pytest.RaisesExc[RuntimeError]
+) -> None:
     """Test hython_docker_image_builder.build._determine_version_info()."""
-    with raiser:
+    with context:
         result = builder._determine_version_info(version_str)
 
         assert result == expected
 
 
 @pytest.mark.parametrize("has_error", (False, True))
-def test__download_file(mocker, has_error):
+def test__download_file(mocker: MockerFixture, has_error: bool) -> None:
     """Test hython_docker_image_builder.build._download_file()."""
     mock_url = mocker.MagicMock(spec=str)
     mock_target = mocker.MagicMock(spec=pathlib.Path)
@@ -68,9 +80,9 @@ def test__download_file(mocker, has_error):
     mock_get = mocker.patch("requests.get")
     mock_get.return_value.status_code = http.HTTPStatus.OK if not has_error else http.HTTPStatus.BAD_REQUEST
 
-    raiser = pytest.raises(RuntimeError) if has_error else contextlib.nullcontext()
+    context = pytest.raises(RuntimeError) if has_error else nullcontext()
 
-    with raiser:
+    with context:
         builder._download_file(mock_url, mock_target)
 
         mock_copy.assert_called_with(mock_get.return_value.raw, mock_target.open.return_value.__enter__.return_value)
@@ -78,74 +90,7 @@ def test__download_file(mocker, has_error):
     mock_get.assert_called_with(mock_url, stream=True)
 
 
-def test__download_product(mocker):
-    """Test hython_docker_image_builder.build._download_product()."""
-    build = {
-        "download_url": "https://some/url",
-        "filename": "houdini-20.0.724-linux_x86_64_gcc11.2.tar.gz",
-        "hash": "b9968530277a07bb50ce0690c0c5bbcd",
-    }
-
-    mock_service = mocker.patch("hython_docker_image_builder.builder.sidefx.service")
-    mock_service.download.get_daily_build_download.return_value = build
-
-    mock_download = mocker.patch("hython_docker_image_builder.builder._download_file")
-    mock_verify = mocker.patch("hython_docker_image_builder.builder._verify_checksum")
-
-    release = {"version": "20.0", "build": "724"}
-
-    mock_target = mocker.MagicMock(spec=pathlib.Path)
-    result = builder._download_product(mock_service, release, "houdini", mock_target)
-
-    assert result == mock_target / build["filename"]
-
-    mock_service.download.get_daily_build_download.assert_called_with(
-        product="houdini",
-        version="20.0",
-        build="724",
-        platform="linux",
-    )
-    mock_download.assert_called_with(build["download_url"], mock_target / build["filename"])
-    mock_verify.assert_called_with(mock_target / build["filename"], build["hash"])
-
-
-@pytest.mark.parametrize(
-    "has_releases,has_build",
-    (
-        (False, False),
-        (True, False),
-        (True, True),
-    ),
-)
-def test__get_target_release(mocker, has_releases, has_build):
-    """Test hython_docker_image_builder.build._get_target_release()."""
-    mock_releases = [mocker.MagicMock(spec=dict)] if has_releases else []
-
-    mock_service = mocker.MagicMock()
-    mock_service.download.get_daily_builds_list.return_value = mock_releases
-
-    mock_version = mocker.MagicMock(spec=str)
-
-    mock_major_minor = mocker.MagicMock(spec=str)
-    build = "123" if has_build else None
-
-    mocker.patch("hython_docker_image_builder.builder._determine_version_info", return_value=(mock_major_minor, build))
-
-    mock_get_release = mocker.patch("hython_docker_image_builder.builder._determine_release")
-
-    raiser = contextlib.nullcontext() if has_releases else pytest.raises(RuntimeError)
-
-    with raiser:
-        result = builder._get_target_release(mock_service, mock_version)
-
-        assert result == mock_get_release.return_value
-
-        mock_service.download.get_daily_builds_list.assert_called_with(
-            product="houdini", version=mock_major_minor, platform="linux", only_production=not has_build
-        )
-
-
-def test__verify_checksum(shared_datadir):
+def test__verify_checksum(shared_datadir: Path) -> None:
     """Test hython_docker_image_builder.build._verify_checksum()."""
     with pytest.raises(RuntimeError):
         builder._verify_checksum(shared_datadir / "verify_checksum.txt", "000")
@@ -170,22 +115,28 @@ def test__verify_checksum(shared_datadir):
     ),
 )
 def test_check_build_can_be_installed(
-    mocker, explicit_version, implicit_version, tag_exists, force, unsupported, no_dockerfile
-):
+    mocker: MockerFixture,
+    explicit_version: str,
+    implicit_version: str,
+    tag_exists: bool,
+    force: bool,
+    unsupported: bool,
+    no_dockerfile: bool,
+) -> None:
     """Test hython_docker_image_builder.build.check_build_can_be_installed()."""
     mock_service = mocker.MagicMock(spec=sidefx._Service)
 
     returned_version = explicit_version or implicit_version
 
     mocker.patch(
-        "hython_docker_image_builder.builder._get_target_release",
+        "hython_docker_image_builder.builder.get_target_release",
         return_value={"version": returned_version, "build": "724"},
     )
 
     mocker.patch("hython_docker_image_builder.builder.docker.check_tag_exists", return_value=tag_exists)
     mocker.patch("hython_docker_image_builder.builder.docker.build_full_tag_name")
 
-    mock_download = mocker.patch("hython_docker_image_builder.builder._download_product")
+    mock_download = mocker.patch("hython_docker_image_builder.builder.download_product")
 
     mock_launcher = mocker.MagicMock(spec=pathlib.Path)
     mock_archive = mocker.MagicMock(spec=pathlib.Path)
@@ -194,13 +145,9 @@ def test_check_build_can_be_installed(
     if no_dockerfile:
         mocker.patch.object(pathlib.Path, "is_dir", return_value=False)
 
-    raiser = (
-        pytest.raises(RuntimeError)
-        if (unsupported and not implicit_version) or no_dockerfile
-        else contextlib.nullcontext()
-    )
+    context = pytest.raises(RuntimeError) if (unsupported and not implicit_version) or no_dockerfile else nullcontext()
 
-    with raiser:
+    with context:
         result = builder.check_build_can_be_installed(mock_service, explicit_version, "name/repo", force=force)
 
         if tag_exists and not force:
@@ -215,7 +162,38 @@ def test_check_build_can_be_installed(
             }
 
 
-def test__get_service(mocker):
+def test_download_product(mocker: MockerFixture) -> None:
+    """Test hython_docker_image_builder.build.download_product()."""
+    build = {
+        "download_url": "https://some/url",
+        "filename": "houdini-20.0.724-linux_x86_64_gcc11.2.tar.gz",
+        "hash": "b9968530277a07bb50ce0690c0c5bbcd",
+    }
+
+    mock_service = mocker.patch("hython_docker_image_builder.builder.sidefx.service")
+    mock_service.download.get_daily_build_download.return_value = build
+
+    mock_download = mocker.patch("hython_docker_image_builder.builder._download_file")
+    mock_verify = mocker.patch("hython_docker_image_builder.builder._verify_checksum")
+
+    release = {"version": "20.0", "build": "724"}
+
+    mock_target = mocker.MagicMock(spec=pathlib.Path)
+    result = builder.download_product(mock_service, release, "houdini", mock_target)
+
+    assert result == mock_target / build["filename"]
+
+    mock_service.download.get_daily_build_download.assert_called_with(
+        product="houdini",
+        version="20.0",
+        build="724",
+        platform="linux_x86_64",
+    )
+    mock_download.assert_called_with(build["download_url"], mock_target / build["filename"])
+    mock_verify.assert_called_with(mock_target / build["filename"], build["hash"])
+
+
+def test_get_service(mocker: MockerFixture) -> None:
     """Test hython_docker_image_builder.build.get_service()."""
     mock_service = mocker.patch("hython_docker_image_builder.builder.sidefx.service")
 
@@ -232,3 +210,39 @@ def test__get_service(mocker):
         client_secret_key=mock_secret,
         endpoint_url=builder.ENDPOINT_URL,
     )
+
+
+@pytest.mark.parametrize(
+    "has_releases,has_build",
+    (
+        (False, False),
+        (True, False),
+        (True, True),
+    ),
+)
+def test_get_target_release(mocker: MockerFixture, has_releases: bool, has_build: bool) -> None:
+    """Test hython_docker_image_builder.build.get_target_release()."""
+    mock_releases = [mocker.MagicMock(spec=dict)] if has_releases else []
+
+    mock_service = mocker.MagicMock()
+    mock_service.download.get_daily_builds_list.return_value = mock_releases
+
+    mock_version = mocker.MagicMock(spec=str)
+
+    mock_major_minor = mocker.MagicMock(spec=str)
+    build = "123" if has_build else None
+
+    mocker.patch("hython_docker_image_builder.builder._determine_version_info", return_value=(mock_major_minor, build))
+
+    mock_get_release = mocker.patch("hython_docker_image_builder.builder._determine_release")
+
+    context = nullcontext() if has_releases else pytest.raises(RuntimeError)
+
+    with context:
+        result = builder.get_target_release(mock_service, mock_version)
+
+        assert result == mock_get_release.return_value
+
+        mock_service.download.get_daily_builds_list.assert_called_with(
+            product="houdini", version=mock_major_minor, platform="linux", only_production=not has_build
+        )

--- a/tests/python/test_docker.py
+++ b/tests/python/test_docker.py
@@ -1,7 +1,11 @@
 """Test the hython_docker_image_builder.docker module."""
 
+# Future
+from __future__ import annotations
+
 # Standard Library
 import subprocess
+from typing import TYPE_CHECKING
 
 # Third Party
 import pytest
@@ -9,19 +13,23 @@ import pytest
 # hython_docker_image_builder
 from hython_docker_image_builder import docker
 
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+    from pytest_subprocess.fake_process import FakeProcess
 
-def test_build_full_tag_name():
+
+def test_build_full_tag_name() -> None:
     """Test hython_docker_image_builder.docker.build_full_tag_name()."""
     result = docker.build_full_tag_name("name/repo", "20.0")
     assert result == "name/repo:20.0"
 
 
 @pytest.mark.parametrize("exists", (False, True))
-def test_check_tag_exists(mocker, fp, exists):
+def test_check_tag_exists(mocker: MockerFixture, fp: FakeProcess, exists: bool) -> None:
     """Test hython_docker_image_builder.docker.check_tag_exists()."""
     mock_build_name = mocker.patch("hython_docker_image_builder.docker.build_full_tag_name")
 
-    def callback_function(*args, **kwargs):
+    def callback_function(*args, **kwargs):  # ruff:ignore[missing-type-args, missing-type-kwargs, missing-return-type-private-function]
         if not exists:
             raise subprocess.CalledProcessError(1, "msg")
 


### PR DESCRIPTION
feat: drop support for 20.5

ci: install package python files as a proper package using poetry

refactor: convert some non-public functions to public for future use in additional scripts

test: switch from mypy to ty for type checking

test: add type hints to test

ci: bump action versions

refactor: misc spelling/grammar fixes in comments